### PR TITLE
build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33
+envlist = py26, py27, py32, py33, py35
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py35
+envlist = py26, py27, py32, py33, py34, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
It's better to build universal wheels if code supports both Python2 and Python3, so I've changed setup.cfg. Also added Python3.4 and Python3.5 to tox.ini.